### PR TITLE
Fix .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -9,9 +9,7 @@ version: 1
 builder:
   configs:
   - platform: linux
-    swift_version:
-    - '5.8'
-    - '5.9'
+    swift_version: '5.8'
     image: registry.gitlab.com/finestructure/spi-images:AppKid-5.8-latest
     documentation_targets:
     - AppKid


### PR DESCRIPTION
I just noticed that your `.spi.yml` file is invalid. If you need configuration for Swift 5.9, you'd need to add a whole new entry under `configs:`.

You can validate your `.spi.yml` file here: https://swiftpackageindex.com/validate-spi-manifest