### PR TITLE
Fix build issue of LinuxSys

### DIFF
--- a/Sys/Package.swift
+++ b/Sys/Package.swift
@@ -11,7 +11,11 @@ import PackageDescription
 let package = Package(
     name: "Sys",
     products: [
-        .library(name: "LinuxSys", targets: ["LinuxSys"]),
+        .library(
+            name: "LinuxSys",
+            type: .static,
+            targets: ["LinuxSys"]
+        ),
     ],
     targets: [
         .target(name: "LinuxSys"),

--- a/Sys/Package.swift
+++ b/Sys/Package.swift
@@ -14,6 +14,6 @@ let package = Package(
         .library(name: "LinuxSys", targets: ["LinuxSys"]),
     ],
     targets: [
-        .systemLibrary(name: "LinuxSys"),
+        .target(name: "LinuxSys"),
     ]
 )


### PR DESCRIPTION
```shell
# On root of the package
swift build --product LinuxSys # ✅ works fine
swift build --product SwiftXlib # ✅ works fine

swift build --package-path ./Sys # ❌ error: 'sys': package has unsupported layout; missing system target module map at '/tmp/AppKid/Sys/Sources/LinuxSys/module.modulemap'
swift build --package-path ./SwiftXlib # ❌ error: 'sys': package has unsupported layout; missing system target module map at '/tmp/AppKid/Sys/Sources/LinuxSys/module.modulemap'
```

The problem is that the target config in `/Sys/Package.swift` is different from `Package.swift`.

https://github.com/smumriak/AppKid/blob/78c9c7e1024ce0ad2255dc4c9403b16b25a860ad/Package.swift#L492-L495